### PR TITLE
Make combined data for AirRepsGPT

### DIFF
--- a/.github/workflows/gpt_data_combined.yml
+++ b/.github/workflows/gpt_data_combined.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Combine Markdown Files
         run: |
-          find . -name "*.md" -exec cat {} + > combined.md
+          find ./docs -name "*.md" -exec cat {} + > combined.md
           echo "Combined Markdown files into combined.md"
 
       - name: Change markdown arrays to csv

--- a/.github/workflows/gpt_data_combined.yml
+++ b/.github/workflows/gpt_data_combined.yml
@@ -1,0 +1,27 @@
+name: Combine Markdown Files for AirRepsGPT
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  combine-markdown:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Combine Markdown Files
+        run: |
+          find . -name "*.md" -exec cat {} + > combined.md
+          echo "Combined Markdown files into combined.md"
+
+      - name: Change markdown arrays to csv
+        run : |
+          cat combined.md | tr -s ' ' | sed 's/ \?| \?/;/g' | sed 's/;-\+.*-\+;//g' > tmp_combined.md && cat tmp_combined.md > combined.md && rm tmp_combined.md
+
+      - name: Upload Combined File as Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: combined-markdown.md
+          path: combined.md


### PR DESCRIPTION
A way to combine every markdown files, and change every arrays to csv, so that LLMs can read it easier.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Documentation content changes

## What is the current behavior?

- Complicated to give data to LLM.

## What is the new behavior?

- Makes new combined_markdown.md file to recover and give as context to LLM.
- Convert markdown arrays to csv for better reading by LLM.
