### PR TITLE
Added multiple warnings for 5.2TB version vol bug

### DIFF
--- a/docs/introduction/sound-quality.md
+++ b/docs/introduction/sound-quality.md
@@ -36,4 +36,6 @@ Some older batches might have a faint clicking sound in one ear when no audio is
 
 ::: warning
 Some older batches might have a faint clicking sound or uneven sound between the ears. Check the troubleshooting section for fixes.
+
+Also, the current AirPods Pro 2 5.2TB version has a 100% Volume bug on macOS. Unfortunately, no solution is available at the moment. We are actively engaging with verified sellers to stay updated on any developments regarding this issue.
 :::

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,6 +12,8 @@ You may receive miss-marketed AirPod Pro clones when ordering on sites like AliE
 #### **macOS Incompatibility with AirPods Pro Replicas**
 One common issue with AirPods Pro replicas is their compatibility with macOS. This issue is caused by the replicas' inability to fully support iCloud, resulting in iCloud verification failure. The issue can be fixed by first forgetting the AirPods on any iCloud device (iOS, iPadOS, WatchOS, etc) you have connected to before.
 
+Also, the current AirPods Pro 2 5.2TB version has a 100% Volume bug on macOS. Unfortunately, no solution is available at the moment. We are actively engaging with verified sellers to stay updated on any developments regarding this issue.
+
 #### **Audio/Video Pausing Frequently with AirPods Pro Replicas**
 Frequent pausing of audio or video while using AirPods Pro replicas is a common issue, often caused by the in-ear detection sensors. This issue can also occur if the AirPods do not fit securely in your ear. To fix this issue, you can either choose other ear tips (on pros) or turn off in-ear detection through settings.
 

--- a/docs/version-info/airpods-pro-2.md
+++ b/docs/version-info/airpods-pro-2.md
@@ -17,6 +17,10 @@ Click the hyper-link on the 'Version' column to find reviews for the given model
 
 **TB** - The TB earbuds is known for its white, tougher case that is more sweatproof than the HR model. It also features a ST gyroscope, similar to the V4.7 and Retail versions, which provides excellent spatial audio. The battery life of the TB model is 8 hours without ANC, and 6 hours with ANC turned on. Tuned to be bass heavy. TB have significant better ANC over Huilian (average 33.6db, peak 39db).
 
+::: warning
+Numerous individuals have reported an issue with this version, noting that this exact version encounters a 100% Volume bug on macOS. Currently, there is no available solution. We are proactively communicating with verified sellers to stay informed about any advancements related to this matter.
+:::
+
 **HR** - The HR earbuds has a yellowish, softer case that is less sweatproof than the TB model.  The battery life of the HR model is 7 hours without ANC, and 5 hours with ANC turned on. Tuned to be bass heavy. HR also has the best transparency & ANC performance (average 34.2db, peak 39db), although it is similar to TB in most situations. 
 
 **Huilian** - The Huilian earbuds is the middle of the pack case, firmer than HR but softer than TB and equiped with 1:1 hinge. However due to Huilian chipset, ANC is significantly worse than the other two model - 5.2TB & 5.2HR (average 30-32 DB, peak 38db). The battery life of the Huilian model is 6 hours without ANC, and 4.5 hours with ANC turned on.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Documentation content changes

## What is the current behavior?

AirPods Pro 2 5.2TB has a confirmed bug with the latest firmware where macOS makes the volume 100% for said replicas. Unfortunately, no solution is available at the moment. I am actively engaging with a verified seller to stay updated on any developments regarding this issue.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added more text on the sound quality page warning label at the sound issue header
- Added text on the troubleshooting page with macOS Incompatibility with AirPods Pro Replicas
- added a warning at the AirPods Pro 2 page with the TB Version. 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Will update the pages based on the information I get from the seller and engineers. 