### PR TITLE
feat(theme): auto-expand FAQ card when its anchor is linked

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -19,5 +19,107 @@ export default {
                 });
             });
         }
+
+        // Open a collapsed <details> (e.g. an FAQ card) when it's the target of
+        // an in-page anchor link. Some links — like the payment table's
+        // "Credit / Debit Card" cell pointing at #credit-card — land on an
+        // anchor that sits right before a `::: details` block; without this the
+        // user arrives on a folded card that looks empty until they click it.
+        if (typeof window !== 'undefined') {
+            // Find the <details> the anchor directly introduces: the anchor
+            // itself, one it wraps, or the very next block after it (climbing
+            // out of an inline wrapper such as the <p> VitePress puts around a
+            // bare `<a id>`). We deliberately do NOT scan past an intervening
+            // block — a heading/TOC link that merely precedes an FAQ section
+            // should not pop a card open.
+            const introducedDetails = (start: Element): HTMLDetailsElement | null => {
+                if (start instanceof HTMLDetailsElement) {
+                    return start;
+                }
+                const within = start.querySelector('details');
+                if (within) {
+                    return within;
+                }
+                let node: Element | null = start;
+                for (let depth = 0; node && depth < 4; depth++) {
+                    const sib = node.nextElementSibling;
+                    if (sib instanceof HTMLDetailsElement) {
+                        return sib;
+                    }
+                    if (sib) {
+                        return null;
+                    }
+                    node = node.parentElement;
+                }
+                return null;
+            };
+
+            const openDetailsForId = (id: string) => {
+                if (!id) {
+                    return;
+                }
+                const el = document.getElementById(id);
+                if (!el) {
+                    return;
+                }
+                const details = introducedDetails(el);
+                if (details && !details.open) {
+                    details.open = true;
+                }
+            };
+
+            const openForHash = () => {
+                const { hash } = window.location;
+                if (hash.length < 2) {
+                    return;
+                }
+                try {
+                    openDetailsForId(decodeURIComponent(hash.slice(1)));
+                } catch {
+                    openDetailsForId(hash.slice(1));
+                }
+            };
+
+            // Same-page anchor clicks are the main case. VitePress may update
+            // the hash via history.pushState (no `hashchange`), so key off the
+            // click itself. Capture phase guarantees we see it regardless of
+            // how the router handles the event.
+            document.addEventListener(
+                'click',
+                (e) => {
+                    const target = e.target as Element | null;
+                    const link = target?.closest?.('a[href*="#"]');
+                    if (!link) {
+                        return;
+                    }
+                    const href = link.getAttribute('href') ?? '';
+                    const id = href.slice(href.indexOf('#') + 1);
+                    if (!id) {
+                        return;
+                    }
+                    let decoded = id;
+                    try {
+                        decoded = decodeURIComponent(id);
+                    } catch {
+                        // keep raw id
+                    }
+                    requestAnimationFrame(() => openDetailsForId(decoded));
+                },
+                { capture: true }
+            );
+            // Direct hash edits and landing fresh with a #hash in the URL.
+            window.addEventListener('hashchange', () => {
+                requestAnimationFrame(openForHash);
+            });
+            window.addEventListener('load', () => {
+                requestAnimationFrame(openForHash);
+            });
+            // SPA navigation to another page that carries a #hash.
+            const prevAfterRouteChange = ctx.router.onAfterRouteChange;
+            ctx.router.onAfterRouteChange = (to: string) => {
+                prevAfterRouteChange?.(to);
+                requestAnimationFrame(() => requestAnimationFrame(openForHash));
+            };
+        }
     },
 };


### PR DESCRIPTION
Clicking the **Credit / Debit Card** cell in the payment table jumps to `#credit-card` — an anchor right before a collapsed `:::details` FAQ explaining the crypto on-ramp. Previously the jump landed on a folded card that looked empty.

This adds a small theme enhancement that opens the `<details>` the anchor directly introduces. Triggers on click (capture phase — VitePress can update the hash via `pushState` without firing `hashchange`), `hashchange`, fresh load with a `#hash`, and SPA route change. Scoped so a heading/TOC link that merely *precedes* a card won't pop it open.

Verified: lint clean, production build green (SSR-guarded), and the open logic traced against the real rendered DOM (`<a id>` wrapped in `<p>`, followed by `<details>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)