### PR TITLE
Add centered download buttons to Useful Apps

### DIFF
--- a/docs/.vitepress/theme/styles/main.css
+++ b/docs/.vitepress/theme/styles/main.css
@@ -99,3 +99,40 @@ iframe[src*="youtube"] {
 .link-column a:hover {
   background: var(--vp-c-default-mute);
 }
+
+/* Compact download links below the Useful Apps images. */
+.app-download-action {
+  display: inline-flex;
+  justify-content: center;
+  /* Match the 128px app images, including their scaling in narrow cells. */
+  width: min(128px, 100%);
+}
+
+.vp-doc a.app-download {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  padding: 0 12px;
+  margin-top: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--vp-c-text-1);
+  white-space: nowrap;
+  text-decoration: none;
+  background-color: rgba(236, 100, 93, 0.1);
+  border: 1px solid var(--vp-c-brand-1);
+  border-radius: 20px;
+  transition: background-color 0.2s;
+}
+
+.vp-doc a.app-download:hover {
+  color: var(--vp-c-text-1);
+  background-color: var(--vp-c-default-soft);
+}
+
+.vp-doc a.app-download:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 3px;
+}

--- a/docs/useful-apps.md
+++ b/docs/useful-apps.md
@@ -11,9 +11,9 @@ Below are apps that can be downloaded to aid you, alongside what versions and ch
 
 ## **TigerBuilder**
 
-|[![FlyCC (Android)](/app_icon/flycc.png)](https://airreps.link/flycc) FlyCC (Android)| [![FlyCC (iOS)](/app_icon/flycc.png)](https://airreps.link/iflycc) FlyCC (iOS) |
+|[![FlyCC (Android)](/app_icon/flycc.png)](https://airreps.link/flycc) FlyCC (Android)<br><span class="app-download-action"><a class="app-download" href="https://airreps.link/flycc" aria-label="Download APK for FlyCC (Android)" target="_blank" rel="noreferrer">Download APK</a></span>| [![FlyCC (iOS)](/app_icon/flycc.png)](https://airreps.link/iflycc) FlyCC (iOS)<br><span class="app-download-action"><a class="app-download" href="https://airreps.link/iflycc" aria-label="Download FlyCC (iOS) on the App Store" target="_blank" rel="noreferrer">App Store</a></span> |
 |---|---|
-| [![CloudCC (Android)](/app_icon/cloudcc.png)](https://airreps.link/cloudcc) CloudCC (Android) | ![Airoha156x (Android)](/app_icon/airoha156x.png) Airoha156x (Android) — Download unavailable |
+| [![CloudCC (Android)](/app_icon/cloudcc.png)](https://airreps.link/cloudcc) CloudCC (Android)<br><span class="app-download-action"><a class="app-download" href="https://airreps.link/cloudcc" aria-label="Download APK for CloudCC (Android)" target="_blank" rel="noreferrer">Download APK</a></span> | ![Airoha156x (Android)](/app_icon/airoha156x.png) Airoha156x (Android) — Download unavailable |
 
 :::warning **CloudCC** has been deprecated since TigerBuilder integrated OTA functionality into FlyCC. It should only be used as a workaround if you encounter the storage permission issue.
 :::
@@ -22,20 +22,20 @@ Below are apps that can be downloaded to aid you, alongside what versions and ch
 
 ## **BES**
 
-| [![HBluetooth (iOS)](/app_icon/hbluetooth.png)](https://airreps.link/hbluetooth) HBluetooth (iOS) |
+| [![HBluetooth (iOS)](/app_icon/hbluetooth.png)](https://airreps.link/hbluetooth) HBluetooth (iOS)<br><span class="app-download-action"><a class="app-download" href="https://airreps.link/hbluetooth" aria-label="Download HBluetooth (iOS) on the App Store" target="_blank" rel="noreferrer">App Store</a></span> |
 |---|
 
 ## **HR**
 
-|[![BullSuper (Android)](/app_icon/bullsuper.png)](https://airreps.link/bullsuperhr) BullSuper (Android)|[![G&Link (iOS)](/app_icon/g&link.png)](https://airreps.link/gnlink) G&Link (iOS)|
+|[![BullSuper (Android)](/app_icon/bullsuper.png)](https://airreps.link/bullsuperhr) BullSuper (Android)<br><span class="app-download-action"><a class="app-download" href="https://airreps.link/bullsuperhr" aria-label="Download APK for BullSuper (Android)" target="_blank" rel="noreferrer">Download APK</a></span>|[![G&Link (iOS)](/app_icon/g&link.png)](https://airreps.link/gnlink) G&Link (iOS)<br><span class="app-download-action"><a class="app-download" href="https://airreps.link/gnlink" aria-label="Download G&amp;Link (iOS) on the App Store" target="_blank" rel="noreferrer">App Store</a></span>|
 |---|---|
 
 ## **Huilian**
 
-|[![StarFun (Android)](/app_icon/starfun.png)](https://airreps.link/starfun) StarFun (Android)|[![StarFun (iOS)](/app_icon/starfun.png)](https://airreps.link/istarfun) StarFun (iOS)|
+|[![StarFun (Android)](/app_icon/starfun.png)](https://airreps.link/starfun) StarFun (Android)<br><span class="app-download-action"><a class="app-download" href="https://airreps.link/starfun" aria-label="Download APK for StarFun (Android)" target="_blank" rel="noreferrer">Download APK</a></span>|[![StarFun (iOS)](/app_icon/starfun.png)](https://airreps.link/istarfun) StarFun (iOS)<br><span class="app-download-action"><a class="app-download" href="https://airreps.link/istarfun" aria-label="Download StarFun (iOS) on the App Store" target="_blank" rel="noreferrer">App Store</a></span>|
 |---|---|
 
 ## **V2.5/KKX**
 
-| [![KKX (Android)](/app_icon/kkx.png)](https://airreps.link/kkx) KKX (Android) |
+| [![KKX (Android)](/app_icon/kkx.png)](https://airreps.link/kkx) KKX (Android)<br><span class="app-download-action"><a class="app-download" href="https://airreps.link/kkx" aria-label="Download APK for KKX (Android)" target="_blank" rel="noreferrer">Download APK</a></span> |
 |---|


### PR DESCRIPTION
The Useful Apps images link to downloads without an obvious action. Add nine small download/App Store buttons centered beneath their corresponding images, including when the images shrink on mobile. Preserve the existing images, destinations, and Airoha156x unavailable state, with app-specific accessible labels and visible keyboard focus.

Validated the reviewed layout at 1280px, 390px, and 375px; all button/image centers align within 0.004 CSS pixels. Existing download destinations were checked, lint and diff checks pass, and the VitePress build passes.